### PR TITLE
fix(ci): カバレッジコメントのリンク404修正とcleanup_pr_comments追加

### DIFF
--- a/.github/workflows/dependabot_prch.yml
+++ b/.github/workflows/dependabot_prch.yml
@@ -41,6 +41,39 @@ jobs:
           json-file: .github/json2vars-setter/matrix.json
 
   # ==========================================================================
+  # 既存PRコメント削除ジョブ
+  # ==========================================================================
+  # 概要: 過去のカバレッジコメントの削除
+  # 処理: testジョブが投稿したPytest Coverage Commentを削除
+  # 補足: 再実行時の重複コメントとリンク切れ(404)コメントの残留を防止
+  # ==========================================================================
+  cleanup_pr_comments:
+    needs: set_variables
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Delete previous coverage comments
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            for (const comment of comments) {
+              if (comment.body && comment.body.startsWith('<!-- Pytest Coverage Comment: test ')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+
+  # ==========================================================================
   # Dependabot依存関係更新テストジョブ
   # ==========================================================================
   # 概要: 依存関係更新の影響検証
@@ -48,7 +81,7 @@ jobs:
   # 補足: マトリックス戦略により9つの組み合わせで並列実行
   # ==========================================================================
   test:
-    needs: set_variables
+    needs: [set_variables, cleanup_pr_comments]
     strategy:
       matrix:
         os: ${{ fromJson(needs.set_variables.outputs.os) }}
@@ -178,6 +211,7 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           pytest-xml-coverage-path: ./coverage.xml
+          coverage-path-prefix: project_a/
           title: 🤖 Dependabot Coverage Report (${{ matrix.os }} / Python ${{ matrix.python-version }})
           badge-title: coverage
           hide-badge: false

--- a/.github/workflows/pullrequest_check.yml
+++ b/.github/workflows/pullrequest_check.yml
@@ -47,6 +47,39 @@ jobs:
           echo "ghpages_branch: ${{ steps.json2vars.outputs.ghpages_branch }}"
 
   # ==========================================================================
+  # 既存PRコメント削除ジョブ
+  # ==========================================================================
+  # 概要: 過去のカバレッジコメントの削除
+  # 処理: testジョブが投稿したPytest Coverage Commentを削除
+  # 補足: 再実行時の重複コメントとリンク切れ(404)コメントの残留を防止
+  # ==========================================================================
+  cleanup_pr_comments:
+    needs: set_variables
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Delete previous coverage comments
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            for (const comment of comments) {
+              if (comment.body && comment.body.startsWith('<!-- Pytest Coverage Comment: test ')) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+
+  # ==========================================================================
   # メインテストジョブ
   # ==========================================================================
   # 概要: クロスプラットフォーム・クロスバージョンテスト
@@ -54,7 +87,7 @@ jobs:
   # 補足: マトリックス戦略により9つの組み合わせで並列実行
   # ==========================================================================
   test:
-    needs: set_variables
+    needs: [set_variables, cleanup_pr_comments]
     strategy:
       matrix:
         os: ${{ fromJson(needs.set_variables.outputs.os) }}
@@ -176,6 +209,7 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           pytest-xml-coverage-path: ./coverage.xml
+          coverage-path-prefix: project_a/
           title: Coverage Report (${{ matrix.os }} / Python ${{ matrix.python-version }})
           badge-title: coverage
           hide-badge: false

--- a/.github/workflows/test_multi_os.yml
+++ b/.github/workflows/test_multi_os.yml
@@ -216,6 +216,7 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           pytest-xml-coverage-path: ./coverage.xml
+          coverage-path-prefix: project_a/
           title: Coverage Report (${{ matrix.os }} / Python ${{ matrix.python-version }})
           badge-title: coverage
           hide-badge: false
@@ -343,10 +344,10 @@ jobs:
           } > README.md
 
           # カバレッジレポート内のリンクを有効にするためにファイルパスを修正する
+          # project_a/プレフィックスはcoverage-path-prefixでアクション側が付与するため、
+          # ここではコミットSHA未解決(undefined)の救済のみを行う
           sed -i '
-            s|/blob/undefined/\([^"]*\)|/blob/'"${commit_hash}"'/\1|g;
-            s|/blob/\([a-f0-9]*\)/\([^"]*\)|/blob/\1/project_a/\2|g;
-            s|/blob/\([a-f0-9]*\)/project_a/README\.md|/blob/\1/README.md|g
+            s|/blob/undefined/\([^"]*\)|/blob/'"${commit_hash}"'/\1|g
           ' README.md
 
       - name: Commit and push


### PR DESCRIPTION
## 概要

`MishaKav/pytest-coverage-comment` が生成するカバレッジコメント内のファイルリンクが **404** になる問題と、再実行時に古いコメントが残留する問題を修正します。参考: [json2vars-setter の dependabot_prch.yml](https://github.com/7rikazhexde/json2vars-setter/blob/main/.github/workflows/dependabot_prch.yml)

## 問題

### 1. pytest結果コメントのリンクが404
`[tool.coverage.run] source = ["project_a"]` のため `coverage.xml` のパスが `project_a/` プレフィックスなし（例: `calculator/xxx.py`）で記録される。MishaKav アクションはこれを `blob/{sha}/calculator/xxx.py` とリンク化するため、実パス `project_a/calculator/xxx.py` と一致せず404になる。

### 2. cleanup_pr_comments の欠落
`create-new-comment: true` で再実行のたびに新規コメントが投稿され、古い（リンク切れを含む）コメントが残留していた。

## 修正内容

| ファイル | cleanup_pr_comments | coverage-path-prefix |
|---|---|---|
| `dependabot_prch.yml` | ✅ 追加 | ✅ `project_a/` |
| `pullrequest_check.yml` | ✅ 追加 | ✅ `project_a/` |
| `test_multi_os.yml` | — (PRコメント投稿なし) | ✅ `project_a/` |

- 全ワークフローに `coverage-path-prefix: project_a/` を追加し、リンクをソース側で正しく生成。
- PRコメント投稿系の2ワークフローに `cleanup_pr_comments` ジョブ（`actions/github-script@v9` で旧コメント削除）を追加し、`test` ジョブを `needs: [set_variables, cleanup_pr_comments]` に変更。
- `test_multi_os.yml` は既存の `sed` による `project_a/` 挿入ハックを廃止（`coverage-path-prefix` と二重付与になるため）。コミットSHA未解決(`undefined`)救済の `sed` のみ残置。

## 確認

- `check-yaml` / 空白・改行系 pre-commit フック: Passed
- 3ワークフローの YAML 構文: 検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
