### PR TITLE
perf(ci): justプレビルド化とconcurrencyでワークフロー高速化

### DIFF
--- a/.github/workflows/dependabot_prch.yml
+++ b/.github/workflows/dependabot_prch.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
 
+# 同一PRへの連続プッシュ時は古い実行をキャンセルしてCI時間を節約
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ==========================================================================
   # 変数設定ジョブ
@@ -130,21 +135,16 @@ jobs:
           uv sync --extra dev
 
       # ======================================================================
-      # Rust環境とキャッシュ
+      # just(タスクランナー)セットアップ
       # ======================================================================
-      # 概要: Rustツールチェーンとjustコマンドのセットアップ
-      # 処理: Rustインストール、キャッシュ、justビルド
-      # 補足: OS別にキャッシュ、cargo install の高速化
+      # 概要: justコマンドのセットアップ
+      # 処理: プレビルドバイナリをダウンロード(Rustコンパイル不要)
+      # 補足: cargo installのコンパイル待ち(数分)を解消しCIを高速化
       # ======================================================================
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2.9.1
-
       - name: Install just
-        run: cargo install just --locked
-        shell: bash
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Verify just
         run: just --version

--- a/.github/workflows/pullrequest_check.yml
+++ b/.github/workflows/pullrequest_check.yml
@@ -13,6 +13,11 @@ on:
     branches:
       - main
 
+# 同一PRへの連続プッシュ時は古い実行をキャンセルしてCI時間を節約
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ==========================================================================
   # 変数設定ジョブ
@@ -134,21 +139,16 @@ jobs:
           uv sync --extra dev
 
       # ======================================================================
-      # Rust環境とキャッシュ
+      # just(タスクランナー)セットアップ
       # ======================================================================
-      # 概要: Rustツールチェーンとjustコマンドのセットアップ
-      # 処理: Rustインストール、キャッシュ、justビルド
-      # 補足: OS別にキャッシュ、cargo install の高速化
+      # 概要: justコマンドのセットアップ
+      # 処理: プレビルドバイナリをダウンロード(Rustコンパイル不要)
+      # 補足: cargo installのコンパイル待ち(数分)を解消しCIを高速化
       # ======================================================================
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2.9.1
-
       - name: Install just
-        run: cargo install just --locked
-        shell: bash
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Verify just
         run: just --version

--- a/.github/workflows/test_multi_os.yml
+++ b/.github/workflows/test_multi_os.yml
@@ -20,6 +20,11 @@ on:
       - 'justfile'
   workflow_dispatch:
 
+# coverageブランチへのpush競合を避けるため同一ブランチの実行を直列化(キャンセルはしない)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ==========================================================================
   # 変数設定ジョブ
@@ -153,21 +158,16 @@ jobs:
           uv sync --extra dev
 
       # ======================================================================
-      # Rust環境とキャッシュ
+      # just(タスクランナー)セットアップ
       # ======================================================================
-      # 概要: Rustツールチェーンとjustコマンドのセットアップ
-      # 処理: Rustインストール、キャッシュ、justビルド
-      # 補足: OS別にキャッシュ、cargo install の高速化
+      # 概要: justコマンドのセットアップ
+      # 処理: プレビルドバイナリをダウンロード(Rustコンパイル不要)
+      # 補足: cargo installのコンパイル待ち(数分)を解消しCIを高速化
       # ======================================================================
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2.9.1
-
       - name: Install just
-        run: cargo install just --locked
-        shell: bash
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Verify just
         run: just --version

--- a/.github/workflows/update_pre-commit_hooks.yml
+++ b/.github/workflows/update_pre-commit_hooks.yml
@@ -98,21 +98,16 @@ jobs:
           uv pip list | grep -E "(pre-commit|ruff|mypy)" || echo "Key tools not found in list"
 
       # ======================================================================
-      # Rust環境とキャッシュ
+      # just(タスクランナー)セットアップ
       # ======================================================================
-      # 概要: Rustツールチェーンとjustコマンドのセットアップ
-      # 処理: Rustインストール、キャッシュ、justビルド
-      # 補足: OS別にキャッシュ、cargo install の高速化
+      # 概要: justコマンドのセットアップ
+      # 処理: プレビルドバイナリをダウンロード(Rustコンパイル不要)
+      # 補足: cargo installのコンパイル待ち(数分)を解消しCIを高速化
       # ======================================================================
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2.9.1
-
       - name: Install just
-        run: cargo install just --locked
-        shell: bash
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Verify installations
         run: |


### PR DESCRIPTION
## 概要

CI の最大ボトルネックだった `cargo install just`（Rustコンパイルで毎回数分）を解消し、ワークフローを高速化します。あわせて `concurrency` による無駄実行の削減を行います。

## 変更内容

### 1. just をプレビルドバイナリ化（高速化の主目的）
- `dtolnay/rust-toolchain` + `Swatinem/rust-cache` + `cargo install just --locked` を、`taiki-e/install-action@v2`（tool: just）の**プレビルドバイナリDL**に置換。
- CI で使う just レシピ（`testcov` → `test-coverage`、`test-ci-full`）は `uv run pytest` のみで **Rust 不要**のため、Rust ツールチェーン/キャッシュを完全撤去しても安全。
- 効果: `just` セットアップが数分のコンパイル → 数秒のDLに短縮（全 OS × Python マトリックスで効く）。

### 2. concurrency 追加
- `pullrequest_check` / `dependabot_prch`: 同一PRへの連続プッシュ時に古い実行をキャンセル（`cancel-in-progress: true`）。
- `test_multi_os`: `coverage` ブランチへの push 競合を避けるため実行を直列化（`cancel-in-progress: false`）。

## 対象ファイル
- `.github/workflows/pullrequest_check.yml`
- `.github/workflows/dependabot_prch.yml`
- `.github/workflows/test_multi_os.yml`
- `.github/workflows/update_pre-commit_hooks.yml`

## 確認
- 4ファイルの YAML 構文: 検証済み
- 残存する `cargo install just` / `rust-toolchain` / `rust-cache` 参照: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
