### PR TITLE
ci(quality): モダン品質ツールの先行導入(zizmor/ty/pip-audit/typos/validate-pyproject)

### DIFF
--- a/.github/workflows/modern-quality.yml
+++ b/.github/workflows/modern-quality.yml
@@ -1,0 +1,138 @@
+# =============================================================================
+# Modern Quality (Preview) Workflow
+# =============================================================================
+# 概要: モダン品質ツールの先行導入(プレビュー)
+# 処理: zizmor/ty/pip-audit/typos/validate-pyproject をuvx経由で実行
+# 補足: スキャナ・プレビュー系はcontinue-on-errorで非ブロッキング。
+#       findingsはStep Summaryとログで可視化し、安定後に必須化を検討する。
+# =============================================================================
+
+name: Modern Quality (Preview)
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - 'project_a/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+  workflow_dispatch:
+
+# 同一参照の古い実行はキャンセルしてCI時間を節約
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ==========================================================================
+  # pyproject.toml 検証 (ゲート)
+  # ==========================================================================
+  # 概要: pyproject.tomlのスキーマ検証
+  # 処理: validate-pyprojectで[project]/[build-system]等を検証
+  # 補足: 設定ミスを早期検出。安全なため唯一のブロッキングジョブ。
+  # ==========================================================================
+  validate-pyproject:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Validate pyproject.toml
+        run: uvx validate-pyproject pyproject.toml
+
+  # ==========================================================================
+  # スペルチェック (typos / プレビュー)
+  # ==========================================================================
+  # 概要: ソース・ドキュメントのスペルミス検出
+  # 処理: crate-ci/typos のプレビルドバイナリで検査
+  # 補足: 誤検出はpyproject.tomlの[tool.typos]で調整。非ブロッキング。
+  # ==========================================================================
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Spell check (typos, preview)
+        uses: crate-ci/typos@v1.47.1
+        continue-on-error: true
+
+  # ==========================================================================
+  # GitHub Actions セキュリティ監査 (zizmor / プレビュー)
+  # ==========================================================================
+  # 概要: ワークフローの脆弱な書き方を静的解析
+  # 処理: zizmorで.github/workflowsを監査
+  # 補足: template-injection等を検出。先行導入のため非ブロッキング。
+  # ==========================================================================
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Audit workflows (zizmor, preview)
+        continue-on-error: true
+        run: |
+          echo "## zizmor (GitHub Actions security, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uvx zizmor --persona=regular .github/workflows 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  # ==========================================================================
+  # 型チェック (ty / プレビュー)
+  # ==========================================================================
+  # 概要: Astral製の高速型チェッカーの先行導入
+  # 処理: uvx ty check で型検査(mypyと併用)
+  # 補足: tyはプレビュー。mypyを正とし、tyは非ブロッキングで評価。
+  # ==========================================================================
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Type check (ty, preview)
+        continue-on-error: true
+        run: |
+          echo "## ty (Astral type checker, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uvx ty check project_a 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  # ==========================================================================
+  # 依存関係 脆弱性スキャン (pip-audit / プレビュー)
+  # ==========================================================================
+  # 概要: 依存関係の既知脆弱性(CVE)検出
+  # 処理: uvでrequirementsをエクスポートしpip-auditで監査
+  # 補足: アドバイザリ検出時も非ブロッキング。サプライチェーン対策。
+  # ==========================================================================
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+      - name: Vulnerability scan (pip-audit, preview)
+        continue-on-error: true
+        run: |
+          uv export --format requirements-txt --no-emit-project --all-extras -o audit-requirements.txt
+          echo "## pip-audit (dependency vulnerabilities, preview)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          uvx pip-audit -r audit-requirements.txt 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/modern-quality.yml
+++ b/.github/workflows/modern-quality.yml
@@ -107,10 +107,12 @@ jobs:
           enable-cache: false
       - name: Type check (ty, preview)
         continue-on-error: true
+        # uv run でプロジェクト環境(依存込み)にtyを注入して実行し、
+        # 第三者ライブラリのimportが解決できるようにする
         run: |
           echo "## ty (Astral type checker, preview)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          uvx ty check project_a 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          uv run --extra dev --with ty ty check project_a 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   # ==========================================================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,18 @@ repos:
         files: ^\.github/workflows/.*\.ya?ml$
         verbose: true
 
+  # pyproject.toml schema validation
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
+  # Spell checking (config: [tool.typos] in pyproject.toml)
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.47.1
+    hooks:
+      - id: typos
+
   # Reference: https://github.com/DavidAnson/markdownlint-cli2#overview
   # > markdownlint-cli is a traditional command-line interface for markdownlint.
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/ci/run_git_tag_base_pyproject.py
+++ b/ci/run_git_tag_base_pyproject.py
@@ -137,14 +137,14 @@ def read_poetry_project_version() -> Tuple[bool, Optional[str]]:
         Tuple[bool, Optional[str]]: Acquisition decision result and [major]. [minor]. [pathch].
     """
     read_success_flag = False
-    curent_ver = ""
+    current_ver = ""
     try:
         # Load the pyproject.toml file
         toml = TOMLFile("pyproject.toml")
         toml_data = toml.read()
         toml_get_data = toml_data.get("tool", {})
         if "poetry" in toml_get_data:
-            curent_ver = toml_get_data["poetry"].get("version", "")
+            current_ver = toml_get_data["poetry"].get("version", "")
             read_success_flag = True
         else:
             error_message = (
@@ -154,7 +154,7 @@ def read_poetry_project_version() -> Tuple[bool, Optional[str]]:
     except Exception as e:
         error_message = f"Failed to update pyproject.toml. Error: {str(e)}"
         sys.exit(error_message)
-    return read_success_flag, curent_ver
+    return read_success_flag, current_ver
 
 
 def get_arg(tag: str) -> str:

--- a/ci/update_pyproject_version.py
+++ b/ci/update_pyproject_version.py
@@ -70,7 +70,7 @@ def create_ver(input_ver: Optional[str]) -> Tuple[bool, str, TOMLFile]:
         input_ver (Optional[str]): [major].[minor].[pathch]
 
     Returns:
-        Tuple[bool, str, TOMLFile]: Infomation of [poetry].[version] in pyproject.toml
+        Tuple[bool, str, TOMLFile]: Information of [poetry].[version] in pyproject.toml
     """
     # Load the pyproject.toml file
     toml = TOMLFile("pyproject.toml")

--- a/justfile
+++ b/justfile
@@ -63,8 +63,29 @@ lint-fix:
 type-check:
     uv run mypy project_a tests ci scripts
 
+# 型チェック(ty / Astral製・プレビュー)。mypyと併用して先行評価
+type-check-ty:
+    uvx ty check project_a
+
 format:
     uv run ruff format
+
+# スペルチェック(typos)。設定は pyproject.toml の [tool.typos]
+spell:
+    uvx typos
+
+# GitHub Actions セキュリティ監査(zizmor)
+audit-actions:
+    uvx zizmor --persona=regular .github/workflows
+
+# 依存関係の脆弱性スキャン(pip-audit)
+audit-deps:
+    uv export --format requirements-txt --no-emit-project --all-extras -o audit-requirements.txt
+    uvx pip-audit -r audit-requirements.txt
+
+# pyproject.toml のスキーマ検証
+validate-pyproject:
+    uvx validate-pyproject pyproject.toml
 
 # 総合的な品質チェック
 check: lint type-check test-coverage

--- a/project_a/account/get_ton_txns_api.py
+++ b/project_a/account/get_ton_txns_api.py
@@ -69,7 +69,7 @@ def save_json_file(data: List[Dict[str, Any]], filename: str) -> None:
     print(f"JSON file saved: {json_file_path}")
 
 
-def get_recieve_txn_tonapi(
+def get_receive_txn_tonapi(
     account_id: str, limit: int = 100, sort_order: str = "desc", save_json: bool = False
 ) -> List[Dict[str, Any]]:  # pragma: no cover
     """Retrieves transactions for a TON account using the TON API.
@@ -93,7 +93,7 @@ def get_recieve_txn_tonapi(
 
     Example:
         >>> account_id = "your_account_id(User-friendly address)"
-        >>> transactions = get_recieve_txn_tonapi(account_id, limit=50, save_json=True)
+        >>> transactions = get_receive_txn_tonapi(account_id, limit=50, save_json=True)
         >>> len(transactions)
         50
     """

--- a/project_a/config.toml
+++ b/project_a/config.toml
@@ -55,7 +55,7 @@ transaction_history_period = 365
 #   Please change Adjust Value to match the value of AMOUNT on the graph.
 staking_calculation_adjustment_value = 5
 
-# Use Hour Infomation for Tonhub API V4
+# Use Hour Information for Tonhub API V4
 # Note:
 #   Required when getting TON staking data.
 #   The timezone in this script is set to Japan Standard Time (JST).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,8 @@ directory = "htmlcov"
 # typos(スペルチェック)設定
 # ドメイン固有語・暗号資産/TON関連の用語を誤検出させないための許可リスト
 [tool.typos.default.extend-words]
-# TON / 暗号資産ドメイン語
+# certifi はPythonパッケージ名(正しい綴り)
+certifi = "certifi"
 
 [tool.typos.files]
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,17 @@ exclude_lines = [
 
 [tool.coverage.html]
 directory = "htmlcov"
+
+# typos(スペルチェック)設定
+# ドメイン固有語・暗号資産/TON関連の用語を誤検出させないための許可リスト
+[tool.typos.default.extend-words]
+# TON / 暗号資産ドメイン語
+
+[tool.typos.files]
+extend-exclude = [
+    "uv.lock",
+    "poetry-pyproject.toml",
+    "htmlcov/",
+    "*.min.css",
+    "*.min.js",
+]


### PR DESCRIPTION
## 概要

モダンな品質・セキュリティツールを **先行導入（プレビュー）** します。CI を壊さないよう、スキャナ／プレビュー系は非ブロッキング（`continue-on-error`）で findings を可視化し、安定後に必須化を検討します。

## 追加ツール（新ワークフロー `modern-quality.yml`、uvx 経由）

| ツール | 役割 | 扱い |
|---|---|---|
| `validate-pyproject` | pyproject.toml スキーマ検証 | **ブロッキング**（安全） |
| `typos` | スペルチェック | preview（`[tool.typos]` で調整） |
| `zizmor` | GitHub Actions セキュリティ監査 | preview（template-injection 等） |
| `ty` | Astral 製 型チェッカー | preview（mypy と併用） |
| `pip-audit` | 依存脆弱性スキャン | preview（サプライチェーン対策） |

## その他
- `.pre-commit-config.yaml`: `validate-pyproject@v0.25` と `typos@v1.47.1` を追加。
- `pyproject.toml`: `[tool.typos]`（誤検出調整・除外パス）を追加。
- `justfile`: `type-check-ty` / `spell` / `audit-actions` / `audit-deps` / `validate-pyproject` レシピを追加。

## 補足
- findings は各ジョブの **Step Summary** とログに出力。zizmor は既存 Discord 通知ステップの `template-injection` を指摘する見込み（別途対応を検討）。
- preview ジョブは失敗してもマージをブロックしません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
