### PR TITLE
docs(zensical): ドキュメントサイトの先行導入(ghpages/docsへ公開)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,95 @@
+# =============================================================================
+# Docs (Zensical) Workflow
+# =============================================================================
+# 概要: Zensicalドキュメントサイトのビルドと公開
+# 処理: docs/ を zensical build で site/ にビルドし、ghpages/docs/ へデプロイ
+# 補足: ghpagesルートのpytestレポートと共存(keep_files: true)。
+#       PRではビルド検証のみ、mainへのpush時のみ公開。
+# =============================================================================
+
+name: Docs (Zensical)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'zensical.toml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'zensical.toml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+# 同一参照の古い実行はキャンセル
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ==========================================================================
+  # ビルド(検証)
+  # ==========================================================================
+  # 概要: zensicalでドキュメントをビルド
+  # 処理: uvx zensical build で site/ を生成しアーティファクト化
+  # 補足: PR/pushの双方で実行し、ビルド可否を検証
+  # ==========================================================================
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+
+      - name: Build docs (zensical)
+        run: uvx zensical build
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: docs-site
+          path: site/
+          retention-days: 7
+
+  # ==========================================================================
+  # デプロイ(公開)
+  # ==========================================================================
+  # 概要: ghpagesブランチのdocs/サブディレクトリへ公開
+  # 処理: peaceiris/actions-gh-pages で site/ を ghpages/docs/ へ配置
+  # 補足: keep_files: true でルートのpytestレポートを保持して共存
+  # ==========================================================================
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download site artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: docs-site
+          path: site
+
+      - name: Deploy to ghpages/docs
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: ghpages
+          destination_dir: docs
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'docs: deploy zensical site to ghpages/docs'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,41 @@
+# CI & Coverage
+
+This project leans on GitHub Actions for testing and for **publishing reports to
+dedicated branches** — a core idea of this template.
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `PR Check (Except Dependabot)` | PR to `main` | Multi-OS / multi-Python tests, 90% coverage gate, coverage PR comment |
+| `Dependabot PR Check` | Dependabot PR | Same checks for dependency-update PRs |
+| `Test Multi-OS` | push to `main` | Tests + publishes the coverage summary to the `coverage` branch |
+| `Modern Quality (Preview)` | PR / push | `zizmor` / `ty` / `pip-audit` / `typos` / `validate-pyproject` (preview) |
+
+All test workflows install `just` from a **prebuilt binary**
+(`taiki-e/install-action`) and use `concurrency` to cancel superseded runs,
+keeping CI fast.
+
+## Branch-managed reports
+
+Rather than committing generated artifacts to `main`, reports live on their own
+branches:
+
+- **`coverage`** — a generated `README.md` with the per-OS / per-Python coverage
+  summary. See the
+  [coverage branch](https://github.com/7rikazhexde/python-project-sandbox/tree/coverage?tab=readme-ov-file#pytest-coverages-summary).
+- **`ghpages`** — pytest **HTML** and **coverage** reports published to GitHub
+  Pages, driven by [pytest-testmon](https://pypi.org/project/pytest-testmon/)
+  incremental runs. See the
+  [reports](https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages?tab=readme-ov-file#pytest-report).
+
+This documentation site is published to the **`docs/` subdirectory of the
+`ghpages` branch**, so it coexists with the pytest reports served from the root.
+
+## Coverage PR comments
+
+Pull requests receive a coverage comment from
+[`pytest-coverage-comment`](https://github.com/marketplace/actions/pytest-coverage-comment).
+File links are resolved with `coverage-path-prefix: project_a/` so they point at
+real source paths, and a `cleanup_pr_comments` job removes stale comments on
+re-runs to avoid broken links.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,68 @@
+# Getting started
+
+## Install
+
+This project uses [uv](https://docs.astral.sh/uv/) for fast Python package
+management.
+
+=== "Production"
+
+    ```bash
+    # Install uv if not already installed
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Install runtime dependencies
+    uv sync
+    ```
+
+=== "Development"
+
+    ```bash
+    # Install dependencies including development tools
+    uv sync --extra dev
+    ```
+
+## Task runner (just)
+
+Common tasks are wrapped with [just](https://github.com/casey/just):
+
+```bash
+just --list            # List all available commands
+just testcov           # Run tests with coverage
+just lint              # Lint with Ruff
+just format            # Format with Ruff
+just type-check        # Type check with mypy
+just check             # Lint + type-check + tests
+```
+
+### Modern tooling (preview)
+
+Early-adopted quality tools are also available as `just` recipes:
+
+```bash
+just type-check-ty     # Type check with ty (Astral, preview)
+just spell             # Spell check with typos
+just audit-actions     # GitHub Actions security audit (zizmor)
+just audit-deps        # Dependency vulnerability scan (pip-audit)
+just validate-pyproject # Validate pyproject.toml schema
+```
+
+## Pre-commit
+
+```bash
+# Install dependencies and the pre-commit hooks
+uv sync --extra dev
+uv run pre-commit install
+
+# Run all hooks against every file
+uv run pre-commit run --all-files
+```
+
+## Build these docs locally
+
+The documentation site is built with [Zensical](https://zensical.org):
+
+```bash
+uvx zensical serve     # Live preview at http://127.0.0.1:8000
+uvx zensical build     # Build static site into ./site
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# python-project-sandbox
+
+A **modern Python project base** for experimenting with tooling — powered by
+[uv](https://docs.astral.sh/uv/), [Ruff](https://docs.astral.sh/ruff/),
+[mypy](https://mypy-lang.org/) and [pytest](https://docs.pytest.org/), with test
+coverage and HTML reports published to dedicated branches via GitHub Actions.
+
+## Highlights
+
+- **Fast tooling** — `uv` for dependency management, `Ruff` for lint/format,
+  `mypy` for type checking, `just` as the task runner.
+- **Branch-managed reports** — coverage summaries are published to the
+  [`coverage`](https://github.com/7rikazhexde/python-project-sandbox/tree/coverage)
+  branch and pytest HTML/cov reports to the
+  [`ghpages`](https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages)
+  branch. See [CI & Coverage](ci.md).
+- **Modern tooling, adopted early** — `zizmor` (Actions security), `ty`
+  (Astral type checker), `pip-audit`, `typos` and `validate-pyproject` run as a
+  preview quality workflow.
+- **Multi-OS / multi-Python CI** — every change is tested across
+  Ubuntu / macOS / Windows on Python 3.11, 3.12 and 3.13.
+
+## Where to next
+
+- [Getting started](getting-started.md) — install dependencies and run the
+  common development tasks.
+- [CI & Coverage](ci.md) — how coverage and reports are built and published.
+
+!!! note "Documentation engine"
+
+    This site is built with [Zensical](https://zensical.org), the next-generation
+    static site generator from the creators of Material for MkDocs, adopted here
+    as an early-access (preview) tool.

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,89 @@
+# =============================================================================
+# Zensical configuration (https://zensical.org)
+# =============================================================================
+# 概要: ドキュメントサイトの設定(Material for MkDocsの後継・先行導入)
+# 出力: docs/ -> site/ をビルドし、ghpages/docs/ へ公開
+# =============================================================================
+
+[project]
+site_name = "python-project-sandbox"
+site_description = "A modern Python project base with uv, Ruff, mypy, pytest and branch-managed coverage/reports."
+site_author = "7rikazhexde"
+# ghpagesルートはpytestレポート用のため、docsはサブディレクトリに公開する
+site_url = "https://7rikazhexde.github.io/python-project-sandbox/docs/"
+copyright = """
+Copyright &copy; 2026 7rikazhexde
+"""
+
+# ナビゲーション(明示定義)。詰め込みすぎず最小構成
+nav = [
+  { "Home" = "index.md" },
+  { "Getting started" = "getting-started.md" },
+  { "CI & Coverage" = "ci.md" },
+]
+
+# ---------------------------------------------------------------------------
+# テーマ設定
+# ---------------------------------------------------------------------------
+[project.theme]
+language = "en"
+features = [
+  "content.code.annotate",
+  "content.code.copy",
+  "content.tabs.link",
+  "navigation.footer",
+  "navigation.indexes",
+  "navigation.instant",
+  "navigation.sections",
+  "navigation.top",
+  "navigation.tracking",
+  "search.highlight",
+]
+
+# ライト/ダーク切替
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+# ---------------------------------------------------------------------------
+# Markdown拡張(Zensicalの既定セット)
+# ---------------------------------------------------------------------------
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## 概要

[Zensical](https://zensical.org)（Material for MkDocs の後継・**alpha**）でドキュメントサイトを**先行導入**します。既存の GitHub Pages（`ghpages` ルートで pytest レポート公開中）を壊さないよう、docs は **`ghpages/docs/` サブディレクトリ**に公開します。

## 変更内容

- **`zensical.toml`**: 最小構成（nav = Home / Getting started / CI & Coverage、light/dark パレット、Zensical 既定の Markdown 拡張）。`site_url` は `…/python-project-sandbox/docs/`。
- **`docs/`**: `index.md` / `getting-started.md` / `ci.md`（README から要点を整理、詰め込みすぎない3ページ）。
- **`.github/workflows/docs.yml`**:
  - `build`: `uvx zensical build` で `site/` を生成（PR ではこの検証のみ）。
  - `deploy`（push to main のみ）: `peaceiris/actions-gh-pages` で `site/` を `ghpages/docs/` へ公開。`keep_files: true` でルートの pytest レポートを保持し**共存**。

## 確認ポイント
- 本PRでは **build ジョブ**が zensical のビルド可否を検証します（デプロイは merge 後の main push で実行）。
- 公開URL（merge後）: `https://7rikazhexde.github.io/python-project-sandbox/docs/`
- `site/` は `.gitignore` 済み。

## 補足
- Zensical は alpha（v0.0.43）。設定は Zensical 公式 bootstrap テンプレートに準拠。安定後に機能追加を検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
