### PR TITLE
docs(readme): Docsバッジとドキュメントリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A modern Python project base for experimenting with tooling — powered by [uv](https://docs.astral.sh/uv/), [Ruff](https://docs.astral.sh/ruff/), [mypy](https://mypy-lang.org/), and [pytest](https://docs.pytest.org/), with test coverage and HTML reports published to dedicated branches via GitHub Actions.
 
 <!-- Status & Stack -->
+[![Docs](https://img.shields.io/badge/docs-zensical-526CFE?logo=materialformkdocs&logoColor=white)](https://7rikazhexde.github.io/python-project-sandbox/docs/)
 [![Test Multi-OS](https://github.com/7rikazhexde/python-project-sandbox/actions/workflows/test_multi_os.yml/badge.svg)](https://github.com/7rikazhexde/python-project-sandbox/actions/workflows/test_multi_os.yml)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue?logo=python&logoColor=white)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/7rikazhexde/python-project-sandbox/blob/main/LICENSE)
@@ -14,6 +15,8 @@ A modern Python project base for experimenting with tooling — powered by [uv](
 **Reports:**
 [![Pytest Coverages Summary](https://img.shields.io/badge/Pytest_Coverages_Summary-gray?logo=python&logoColor=white)](https://github.com/7rikazhexde/python-project-sandbox/tree/coverage?tab=readme-ov-file#pytest-coverages-summary)
 [![Pytest Reports](https://img.shields.io/badge/Pytest_Reports-gray?logo=python&logoColor=white)](https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages?tab=readme-ov-file#pytest-report)
+
+📖 **Documentation:** <https://7rikazhexde.github.io/python-project-sandbox/docs/>
 
 ## Table of Contents
 


### PR DESCRIPTION
Docs サイトの導線改善。READMEに「Docs」バッジ + 明示URLを追加。

URL: https://7rikazhexde.github.io/python-project-sandbox/docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)