### PR TITLE
docs(zensical): レポートハブ化とpytest-html CSS解説の追加

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,8 @@ coverage and HTML reports published to dedicated branches via GitHub Actions.
   [`coverage`](https://github.com/7rikazhexde/python-project-sandbox/tree/coverage)
   branch and pytest HTML/cov reports to the
   [`ghpages`](https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages)
-  branch. See [CI & Coverage](ci.md).
+  branch. See [Reports & coverage](reports.md) for live links and the
+  pytest-html styling setup, and [CI & Coverage](ci.md) for the pipeline.
 - **Modern tooling, adopted early** — `zizmor` (Actions security), `ty`
   (Astral type checker), `pip-audit`, `typos` and `validate-pyproject` run as a
   preview quality workflow.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,74 @@
+# Reports & coverage
+
+This project keeps **report generation independent** (each report is produced by
+a different tool across an OS / Python matrix) but uses this documentation site
+as the **hub** that links them together. Nothing is coupled at build time — the
+docs simply point at the published artifacts.
+
+## What is published, and where
+
+| Report | Tool | Location |
+| --- | --- | --- |
+| Coverage summary | `pytest-coverage-comment` | [`coverage` branch README](https://github.com/7rikazhexde/python-project-sandbox/tree/coverage?tab=readme-ov-file#pytest-coverages-summary) |
+| Coverage HTML | `pytest-cov` | `ghpages` → `pytest-cov-report/<os>/python/<version>/` |
+| Test report HTML | `pytest-html` | `ghpages` → `pytest-html-report/<os>/python/<version>/` |
+
+The HTML reports are driven by [pytest-testmon](https://pypi.org/project/pytest-testmon/)
+incremental runs and deployed per OS / Python version. The canonical index — kept
+up to date with the current matrix — lives in the
+[`ghpages` branch README](https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages?tab=readme-ov-file#pytest-report).
+
+### Live links
+
+- **Indexes (recommended entry points):**
+    - Coverage summary → <https://github.com/7rikazhexde/python-project-sandbox/tree/coverage?tab=readme-ov-file#pytest-coverages-summary>
+    - HTML / cov reports → <https://github.com/7rikazhexde/python-project-sandbox/tree/ghpages?tab=readme-ov-file#pytest-report>
+- **Direct URL pattern** (replace `<os>` / `<version>`):
+    - Test report: `…/python-project-sandbox/pytest-html-report/<os>/python/<version>/report_page.html`
+    - Coverage:    `…/python-project-sandbox/pytest-cov-report/<os>/python/<version>/index.html`
+- **Concrete example** (ubuntu-latest / Python 3.11.9):
+    - [Test report](https://7rikazhexde.github.io/python-project-sandbox/pytest-html-report/ubuntu-latest/python/3.11.9/report_page.html)
+    - [Coverage](https://7rikazhexde.github.io/python-project-sandbox/pytest-cov-report/ubuntu-latest/python/3.11.9/index.html)
+
+!!! note "Why not serve reports from this site?"
+
+    The reports are large, self-contained HTML generated independently for each
+    of `ubuntu` / `macos` / `windows` × Python `3.12` / `3.13` (and more), using
+    `pytest-testmon` incremental state. Keeping generation separate avoids
+    coupling two pipelines and bloating the docs build — this page is the hub,
+    the reports stay independent.
+
+## pytest-html styling (custom CSS)
+
+The HTML test report is themed with a custom stylesheet at
+[`css/style.css`](https://github.com/7rikazhexde/python-project-sandbox/blob/main/css/style.css).
+It is applied with pytest-html's `--css` option, and `--self-contained-html`
+inlines the CSS so the published `report_page.html` is a single portable file:
+
+```bash
+uv run pytest \
+  --html=htmlcov/report_page.html \
+  --self-contained-html \
+  --css=css/style.css \
+  --capture=no \
+  project_a tests/
+```
+
+Or via the task runner:
+
+```bash
+just testhtml          # -> htmlcov/report_page.html (styled)
+```
+
+In CI, the same `--css=css/style.css` is passed in
+`test_pytest-html-report_deploy_multi_os.yml` before the report is published to
+`ghpages`.
+
+!!! tip "Reproduce this setup in your own project"
+
+    1. Add a stylesheet (e.g. `css/style.css`).
+    2. Generate the report with `--html=… --self-contained-html --css=css/style.css`.
+    3. Publish the per-matrix output to a `ghpages` subdirectory (this project
+       uses `pytest-<html|cov>-report/<os>/python/<version>/`), keeping existing
+       files so the reports and these docs coexist.
+    4. Link everything from a single hub page — like this one.

--- a/zensical.toml
+++ b/zensical.toml
@@ -20,6 +20,7 @@ nav = [
   { "Home" = "index.md" },
   { "Getting started" = "getting-started.md" },
   { "CI & Coverage" = "ci.md" },
+  { "Reports & coverage" = "reports.md" },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要
docsとテストレポートの関連が弱い・pytest-htmlのCSS説明が無い点を解消します。

**方針(ご質問への回答):** レポート*生成*は独立のまま(別ツール・OS別マトリックス・巨大な自己完結HTMLのため統合は脆い)、zensical docsを**ハブ**として相互リンク+解説する構成が構造的ベスト。

## 変更
- `docs/reports.md`(新規): pytest-cov/pytest-html/coverage summary の公開先・索引・URLパターン・具体例を集約。**pytest-html のカスタムCSS**(`css/style.css` を `--css`/`--self-contained-html` で適用)、`just testhtml`、CI適用、**再現手順**を明記。独立維持の理由も記載。
- `zensical.toml`: nav に「Reports & coverage」を追加。
- `docs/index.md`: ハブページへのリンク追加。

## 確認
- docs build ジョブで reports.md のレンダリングと nav を検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)