### PR TITLE
fix(test): pytest 9.1対応 (PytestRemovedIn9Warningフィルタ除去)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,9 +123,6 @@ testpaths = ["project_a", "tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-filterwarnings = [
-    "ignore::pytest.PytestRemovedIn9Warning"
-]
 
 # カバレッジ設定
 [tool.coverage.run]


### PR DESCRIPTION
## 概要
pytest 9.1.0 で `pytest.PytestRemovedIn9Warning` が**削除**され、`pyproject.toml` の
`filterwarnings = ["ignore::pytest.PytestRemovedIn9Warning"]` がパースエラー
(AttributeError)→ pytest が exit code 4 で失敗していました。

Dependabot の pytest 9.0.3→9.1.0 更新 PR #614 の全 test ジョブ失敗の原因です。
不要になった当該フィルタを削除します。

## 確認
- TOML 構文 検証済み
- マージ後、#614 を rebase すれば CI は解消見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)