### PR TITLE
fix(ci): ghpagesへのpush競合(non-fast-forward)を解消し全デプロイジョブを直列化

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,6 +73,10 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # ghpagesへ書き込む全ジョブで共通グループを使い直列化する(push競合防止)
+    concurrency:
+      group: ghpages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test_pytest-cov-report_deploy_multi_os.yml
+++ b/.github/workflows/test_pytest-cov-report_deploy_multi_os.yml
@@ -103,6 +103,10 @@ jobs:
   deploy:
     needs: test-and-coverage
     runs-on: ubuntu-latest
+    # ghpagesへ書き込む全ジョブで共通グループを使い直列化する(push競合防止)
+    concurrency:
+      group: ghpages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/test_pytest-html-report_deploy_multi_os.yml
+++ b/.github/workflows/test_pytest-html-report_deploy_multi_os.yml
@@ -103,6 +103,10 @@ jobs:
   deploy:
     needs: test-and-report
     runs-on: ubuntu-latest
+    # ghpagesへ書き込む全ジョブで共通グループを使い直列化する(push競合防止)
+    concurrency:
+      group: ghpages-deploy
+      cancel-in-progress: false
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/test_pytest-testmon_deploy_multi_os.yml
+++ b/.github/workflows/test_pytest-testmon_deploy_multi_os.yml
@@ -296,8 +296,10 @@ jobs:
     needs: test-and-deploy-testmon
     if: contains(needs.test-and-deploy-testmon.result, 'success')
     runs-on: ubuntu-latest
+    # ghpagesへ書き込む全ジョブで共通グループを使い、リポジトリ全体で直列化する
+    # (push競合そのものを防ぐ多重防御)
     concurrency:
-      group: deploy-testmon-ghpages
+      group: ghpages-deploy
       cancel-in-progress: false
     permissions:
       contents: write
@@ -325,6 +327,8 @@ jobs:
           echo "Deploying testmon data to ${ghpages_branch}..."
           git fetch origin "${ghpages_branch}" || git checkout -b "${ghpages_branch}"
           git checkout "${ghpages_branch}"
+          # 他のデプロイジョブが先にpushしている可能性があるため最新化する
+          git pull origin "${ghpages_branch}" --rebase || true
 
           changes_made=false
 
@@ -348,8 +352,25 @@ jobs:
 
           if [ "${changes_made}" = true ]; then
             git commit -m "Update testmon data on GitHub Pages"
-            git push origin "${ghpages_branch}"
-            echo "deploy_status=updated" >> "$GITHUB_OUTPUT"
+
+            # Push with retry (他のワークフローとの競合に対応)
+            max_retries=5
+            retry_count=0
+            while [ $retry_count -lt $max_retries ]; do
+              if git push origin "${ghpages_branch}"; then
+                echo "deploy_status=updated" >> "$GITHUB_OUTPUT"
+                break
+              else
+                retry_count=$((retry_count + 1))
+                if [ $retry_count -lt $max_retries ]; then
+                  echo "Push failed, retrying ($retry_count/$max_retries)..."
+                  git pull origin "${ghpages_branch}" --rebase
+                else
+                  echo "Push failed after $max_retries retries"
+                  exit 1
+                fi
+              fi
+            done
           else
             echo "No changes to commit"
             echo "deploy_status=unchanged" >> "$GITHUB_OUTPUT"
@@ -368,7 +389,7 @@ jobs:
     if: contains(needs.test-and-deploy-testmon.result, 'success')
     runs-on: ubuntu-latest
     concurrency:
-      group: deploy-reports-${{ github.ref }}
+      group: ghpages-deploy
       cancel-in-progress: false
     permissions:
       contents: write


### PR DESCRIPTION
## 背景 / 問題

`main` への push で **`pytest-testmon Deploy Multi-OS`** が失敗していた（[該当run](https://github.com/7rikazhexde/python-project-sandbox/actions/runs/30197361386)）。

```
! [remote rejected] ghpages -> ghpages (cannot lock ref 'refs/heads/ghpages':
  is at d38faa6c... but expected 62310c94...)
error: failed to push some refs
```

### 原因

`ghpages` ブランチへ書き込むジョブが複数同時に走り、**push が non-fast-forward で弾かれる競合（race condition）**。

- `deploy-reports` / cov / html ジョブ … **リトライ＋rebase ループ**を持つ → 競合しても勝てる
- `deploy-testmon` ジョブ … **素の `git push`（rebase・retry なし）** → 競合の敗者になり失敗
- さらに `deploy-testmon` と `deploy-reports` は **concurrency グループが別**で同時実行されていた

## 修正内容

### 1. 根本修正 — `deploy-testmon` を他ジョブと同じ堅牢な push に

- ステージ前に `git pull origin ghpages --rebase` で最新化
- push を **リトライ＋rebase ループ**（最大5回）に変更

### 2. 再発防止（多重防御）— ghpages 書き込みジョブを全て直列化

`ghpages` へ書き込む全ジョブの concurrency グループを共通の **`ghpages-deploy`（`cancel-in-progress: false`）** に統一。リポジトリ全体で1つずつ順に実行され、**競合そのものが発生しなくなる**。

| ワークフロー / ジョブ | 変更前 group | 変更後 group |
| --- | --- | --- |
| testmon `deploy-testmon` | `deploy-testmon-ghpages` | `ghpages-deploy` |
| testmon `deploy-reports` | `deploy-reports-${{ github.ref }}` | `ghpages-deploy` |
| cov `deploy` | （なし） | `ghpages-deploy` |
| html `deploy` | （なし） | `ghpages-deploy` |
| docs `deploy` | （なし・ジョブ単位で追加） | `ghpages-deploy` |

## 検証

- 4ワークフローの YAML パースを確認（pyyaml `safe_load` OK）
- これらのデプロイジョブは `push`（main）/ `workflow_dispatch` トリガーのため **PR 上では実行されない**。マージ後、次の `main` への push または手動実行で `deploy-testmon` が緑になることで最終確認できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)